### PR TITLE
Fix repo2data redownload

### DIFF
--- a/binder/data_requirement.json
+++ b/binder/data_requirement.json
@@ -1,4 +1,4 @@
 { "src": "https://ndownloader.figshare.com/files/9843721",
-  "dst": "./data",
+  "dst": "../data",
   "projectName": "editorial_parcellation",
   "recursive": true}


### PR DESCRIPTION
@pbellec repo2data expects the data folder to be at the root of the repository (that's where neurolibre mounts). Relative to the `data_requirement.json`, it corresponds to `../data`. When `./data` is provided, during the binder run, it attempts downloading to under the binder folder. 